### PR TITLE
retry if lseek(2) doesn't support SEEK_DATA or SEEK_HOLE

### DIFF
--- a/lib/lseek64_stubs.c
+++ b/lib/lseek64_stubs.c
@@ -17,6 +17,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/ioctl.h>
+#include <errno.h>
 
 #include <fcntl.h>
 #include <string.h>
@@ -48,6 +49,9 @@ CAMLprim value stub_lseek64_data(value fd, value ofs) {
   caml_enter_blocking_section();
 #if defined(SEEK_DATA)
   c_ret = lseek(c_fd, c_ofs, SEEK_DATA);
+  /* retry, if SEEK_DATA not supported on this file system */
+  if (c_ret == -1 && errno == EINVAL)
+    c_ret = lseek(c_fd, c_ofs, SEEK_SET);
 #else
   /* Set the file pointer to ofs; pretend there is data */
   c_ret = lseek(c_fd, c_ofs, SEEK_SET);
@@ -69,6 +73,9 @@ CAMLprim value stub_lseek64_hole(value fd, value ofs) {
   caml_enter_blocking_section();
 #if defined(SEEK_HOLE)
   c_ret = lseek(c_fd, c_ofs, SEEK_HOLE);
+  /* retry, if SEEK_HOLE not supported on this file system */
+  if (c_ret == -1 && errno == EINVAL)
+    c_ret = lseek(c_fd, c_ofs, SEEK_END);
 #else
   /* Set the file pointer to the end of the file; pretend
      there is no hole */


### PR DESCRIPTION
This PR tries to improve https://github.com/djs55/ocaml-vhd/pull/33. Improvement are:

* We keep using `#ifdef` to make sure to only use `SEEK_DATA`, `SEEK_HOLE`  when it is defined on a platform.

* We retry when `lseek(2)` fails only when it is because the file system  doesn't support `SEEK_DATA` or `SEEK_HOLE`. The previous patch retried  irrespective of the reason for failure.

I'd like to mention remarks from an internal discussion on the design in general:

* A wrapper around `lseek` like this should communicate problems rather than trying a fallback. This would mean that more details need to be exposed by the wrapper.

* If a file descriptor is known not to support `SEEK_DATA` and the like, it would be better not to try it repeatedly but to associate this information with the file descriptor. This, again, would mean a different interface that exposes these details at the OCaml level. 

* For the given use case the PR is probably still the right thing as it increases abstraction at a small performance cost (of dynamically trying a system call that could be known to fail).

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>